### PR TITLE
Support EdgeRc configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ optional arguments:
   --eg-section EG_SECTION
                         Section of the config file for the desired OPEN API
                         credentials.
-  --eg-verbose          Enable verbose logging output
+  --eg-verbose          Enable verbose logging output (repeat for even more)
   -d DATA, --data DATA, --data-ascii DATA
                         ASCII data content for POST body
   --data-binary DATA_BINARY

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install httpie-edgegrid
 The examples and guides on the developer portal are moving to this new tool, so please consider using it for your API calls.
 
 ## CHANGES
-2016-08-31
+2016-11-07
 * Add support for EdgeRc configuration files.
 
 2016-08-25
@@ -146,7 +146,7 @@ access_token = akaa-ublu6mqdcqkjw5lz-542a56pcogddddow
 client_secret = SOMESECRET
 client_token = akaa-nev5k66unzize2gx-5uz4svbszp4ko5wq
 host = akaa-u5x3btzf44hplb4q-6jrzwnvo7llch3po.luna.akamaiapis.net
-max-body = 2048
+max-body = 131072
 ```
 
 Here is an example invocation:

--- a/convert_egcurl.pl
+++ b/convert_egcurl.pl
@@ -10,10 +10,10 @@ while (<STDIN>) {
     }
     chomp($_);
     $_ =~ s/secret/client_secret/go;
-    $_ =~ s/:/ = /go;
     my @options = split(/ +/, $_);
     @options = sort(@options);
     foreach my $thing (@options) {
+        $thing =~ s/:/ = /go;
         print($thing . "\n");
     }
 }

--- a/convert_egcurl.pl
+++ b/convert_egcurl.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+while (<STDIN>) {
+    if ($_ =~ /^\s*($|#|;)/o || $_ =~ /^\s*\[(.+?)\]\s*$/) {
+        print($_);
+        next;
+    }
+    chomp($_);
+    $_ =~ s/secret/client_secret/go;
+    $_ =~ s/:/ = /go;
+    my @options = split(/ +/, $_);
+    @options = sort(@options);
+    foreach my $thing (@options) {
+        print($thing . "\n");
+    }
+}

--- a/egcurl
+++ b/egcurl
@@ -179,8 +179,8 @@ def get_parser():
                         help='Section of the config file for the desired OPEN API credentials.')
     parser.add_argument('--eg-verbose',
                         default=False,
-                        help='Enable verbose logging output',
-                        action='store_true')
+                        help='Enable verbose logging output (repeat for even more)',
+                        action='count')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-d', '--data', '--data-ascii',
                         help='ASCII data content for POST body')
@@ -193,7 +193,9 @@ def get_parser():
     parser.add_argument('url',
                         help='Request URL')
     (args, args_unknown) = parser.parse_known_args()
-    if args.eg_verbose:
+    if args.eg_verbose == 1:
+        log.setLevel(logging.INFO)
+    elif args.eg_verbose >= 2:
         log.setLevel(logging.DEBUG)
 
     log.info('Parsed known arguments: %s', pformat(args))
@@ -280,7 +282,7 @@ def main():
         curl_args.extend([ '--data-binary', args.data_binary ])
     curl_args.extend(args_unknown + [ url ])
 
-    log.info("cURL arguments: %s", pformat(curl_args))
+    log.info("cURL command: %s", " ".join(curl_args))
     sys.stdout.flush()
 
     os.execvp(curl_args[0], curl_args)

--- a/egcurl
+++ b/egcurl
@@ -71,6 +71,36 @@ class MockRequest:
     def register_hook(self, ignoredA, ignoredB):
         return
 
+def get_config(edgerc_filename, egconf_filename, section):
+    if os.path.isfile(egconf_filename):
+        configs = _parse_egcurl(egconf_filename)
+        if section in configs:
+            logging.warn("Using configuraton from deprecated egconfig file '%s'. Please migrate to ~/.edgerc.", egconf_filename)
+            config = configs[section]
+            return config
+
+    config = _parse_edgerc(edgerc_filename, section)
+    return config
+
+def _parse_edgerc(file, section):
+    if not os.path.isfile(file):
+        return None
+    edgerc = EdgeRc(file)
+    config = {
+        "access_token": edgerc.get(section, 'access_token'),
+        "client_token": edgerc.get(section, 'client_token'),
+        "host": edgerc.get(section, 'host'),
+        "max-body": edgerc.getint(section, 'max-body'),
+        "secret": edgerc.get(section, 'client_secret'),
+        "signed-header": edgerc.get(section, 'headers_to_sign')
+    }
+
+    # The EdgeRc library ensures the whole file must be valid. If host is empty then there's no config found.
+    if config['host'] is None:
+        return None
+
+    return config
+
 def _parse_egcurl(file):
     configs = {}
     with open(file, "r") as f:
@@ -137,9 +167,13 @@ def get_parser():
                         action='append',
                         default = [],
                         help='HTTP headers to pass on to cURL (repeatable)')
-    parser.add_argument("--eg-config",
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--eg-edgerc",
+                        default=os.environ["HOME"] + "/.edgerc",
+                        help='Location of EdgeRc configuration ini file.')
+    group.add_argument("--eg-config",
                         default=os.environ["HOME"] + "/.egcurl",
-                        help='Location of configuration ini file.')
+                        help='Location of older configuration file (DEPRECATED).')
     parser.add_argument("--eg-section",
                         default = "default",
                         help='Section of the config file for the desired OPEN API credentials.')
@@ -208,8 +242,8 @@ def main():
             if header_value:
                 headers[header_name.lower()] = header_value
 
-    configs = _parse_egcurl(args.eg_config)
-    config = configs[section]
+    config = get_config(args.eg_edgerc, args.eg_config, section)
+
     if not config:
         raise ValueError("Config section was invalid or not found.")
 
@@ -254,6 +288,7 @@ def main():
 if __name__ == "__main__":
     try:
         from akamai.edgegrid import EdgeGridAuth
+        from akamai.edgegrid import EdgeRc
     except ImportError:
         print("""
 This tool has been updated to use the Akamai EdgeGrid for Python library


### PR DESCRIPTION
This pull request adds support for ~/.edgerc files using the EdgeRc python library. Support for the older ~/.egcurl config files is maintained, and takes precedence in case both files are present.

A conversion tool is included with instructions for converting an existing ~/.egcurl into a ~/.edgerc. I am not totally sold on the name of this script... I'm open to suggestions on better names for it.

Please review all the README.md updates. It's pretty different compared to before. The mentions of ~/.egcurl all indicate its deprecated status and we don't explain how those files work anymore. I've copied some sample stuff from the edgegrid-httpie project's readme.
