### PR TITLE
Restore missing return statement, fixes POSTs

### DIFF
--- a/egcurl
+++ b/egcurl
@@ -67,6 +67,7 @@ class MockRequest:
                     return data
             except IOError:
                 raise
+        return data
 
     def register_hook(self, ignoredA, ignoredB):
         return


### PR DESCRIPTION
We seem to have lost a return statement at the end of the function that gets the request body for signing. This caused POSTs to fail signature checking if the user used inline POST body (`-d`, `--data`, etc).